### PR TITLE
Delete sub command and download optimizations

### DIFF
--- a/src/main/java/net/craftcitizen/imagemaps/ImageMapCommandHandler.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMapCommandHandler.java
@@ -6,6 +6,7 @@ public class ImageMapCommandHandler extends CommandHandler {
     public ImageMapCommandHandler(ImageMaps plugin) {
         super(plugin);
         registerSubCommand("download", new ImageMapDownloadCommand(plugin));
+        registerSubCommand("delete", new ImageMapDeleteCommand(plugin));
         registerSubCommand("place", new ImageMapPlaceCommand(plugin));
         registerSubCommand("info", new ImageMapInfoCommand(plugin));
         registerSubCommand("list", new ImageMapListCommand(plugin));

--- a/src/main/java/net/craftcitizen/imagemaps/ImageMapDeleteCommand.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMapDeleteCommand.java
@@ -1,0 +1,64 @@
+package net.craftcitizen.imagemaps;
+
+import de.craftlancer.core.Utils;
+import de.craftlancer.core.util.MessageLevel;
+import de.craftlancer.core.util.MessageUtil;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+public class ImageMapDeleteCommand extends ImageMapSubCommand {
+
+    public ImageMapDeleteCommand(ImageMaps plugin) {
+        super("imagemaps.delete", plugin, true);
+    }
+
+    @Override
+    protected String execute(CommandSender sender, Command cmd, String label, String[] args) {
+        if (!checkSender(sender)) {
+            MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "You can't run this command.");
+            return null;
+        }
+
+        if (args.length < 2) {
+            MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "You must specify a file name.");
+            return null;
+        }
+
+        String filename = args[1];
+
+        if (filename.contains("/") || filename.contains("\\") || filename.contains(":")) {
+            MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "Filename contains illegal character.");
+            return null;
+        }
+
+        if (!getPlugin().hasImage(filename)) {
+            MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "No image with this name exists.");
+            return null;
+        }
+
+        if (getPlugin().deleteImage(filename)) {
+            MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, "File deleted.");
+        } else {
+            MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "Failed to delete file.");
+        }
+        return null;
+    }
+
+    @Override
+    public void help(CommandSender sender) {
+        MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, "Deletes an image.");
+        MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.INFO, "Usage: /imagemap delete <filename>");
+    }
+
+    @Override
+    protected List<String> onTabComplete(CommandSender sender, String[] args) {
+        if (args.length == 2)
+            return Utils.getMatches(args[1], new File(plugin.getDataFolder(), "images").list());
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/net/craftcitizen/imagemaps/ImageMapDownloadCommand.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMapDownloadCommand.java
@@ -1,5 +1,12 @@
 package net.craftcitizen.imagemaps;
 
+import de.craftlancer.core.LambdaRunnable;
+import de.craftlancer.core.util.MessageLevel;
+import de.craftlancer.core.util.MessageUtil;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -9,66 +16,59 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 
-import javax.imageio.ImageIO;
-
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-
-import de.craftlancer.core.LambdaRunnable;
-import de.craftlancer.core.util.MessageLevel;
-import de.craftlancer.core.util.MessageUtil;
-
 public class ImageMapDownloadCommand extends ImageMapSubCommand {
-    
+
     public ImageMapDownloadCommand(ImageMaps plugin) {
         super("imagemaps.download", plugin, true);
     }
-    
+
     @Override
     protected String execute(CommandSender sender, Command cmd, String label, String[] args) {
         if (!checkSender(sender)) {
             MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "You can't run this command.");
             return null;
         }
-        
+
         if (args.length < 3) {
             MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "You must specify a file name and a download link.");
             return null;
         }
-        
+
         String filename = args[1];
         String url = args[2];
-        
+
         if (filename.contains("/") || filename.contains("\\") || filename.contains(":")) {
             MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "Filename contains illegal character.");
             return null;
         }
-        
+
         new LambdaRunnable(() -> download(sender, url, filename)).runTaskAsynchronously(plugin);
         return null;
     }
-    
+
     private void download(CommandSender sender, String input, String filename) {
         try {
             URL srcURL = new URL(input);
-            
+
             if (!srcURL.getProtocol().startsWith("http")) {
                 MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "Download URL is not valid.");
                 return;
             }
-            
+
             URLConnection connection = srcURL.openConnection();
-            
+
             if (!(connection instanceof HttpURLConnection)) {
                 MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "Download URL is not valid.");
                 return;
             }
-            
+
+            connection.setRequestProperty("User-Agent", "ImageMap/0");
+
             if (((HttpURLConnection) connection).getResponseCode() != 200) {
                 MessageUtil.sendMessage(getPlugin(),
-                                        sender,
-                                        MessageLevel.WARNING,
-                                        String.format("Download failed, HTTP Error code %d.", ((HttpURLConnection) connection).getResponseCode()));
+                        sender,
+                        MessageLevel.WARNING,
+                        String.format("Download failed, HTTP Error code %d.", ((HttpURLConnection) connection).getResponseCode()));
                 return;
             }
             
@@ -88,16 +88,14 @@ public class ImageMapDownloadCommand extends ImageMapSubCommand {
                 ImageIO.write(iamge, "PNG", new File(plugin.getDataFolder(), "images" + File.separatorChar + filename));
             }
             MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, "Download complete.");
-        }
-        catch (MalformedURLException ex) {
+        } catch (MalformedURLException ex) {
             MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "Malformatted URL");
-        }
-        catch (IOException ex) {
+        } catch (IOException ex) {
             MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.ERROR, "An IO Exception happened, see server log");
             ex.printStackTrace();
         }
     }
-    
+
     @Override
     public void help(CommandSender sender) {
         MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, "Downloads an image from an URL.");

--- a/src/main/java/net/craftcitizen/imagemaps/ImageMapDownloadCommand.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMapDownloadCommand.java
@@ -62,7 +62,7 @@ public class ImageMapDownloadCommand extends ImageMapSubCommand {
                 return;
             }
 
-            connection.setRequestProperty("User-Agent", "ImageMap/0");
+            connection.setRequestProperty("User-Agent", "ImageMaps/0");
 
             if (((HttpURLConnection) connection).getResponseCode() != 200) {
                 MessageUtil.sendMessage(getPlugin(),

--- a/src/main/java/net/craftcitizen/imagemaps/ImageMapDownloadCommand.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMapDownloadCommand.java
@@ -80,15 +80,21 @@ public class ImageMapDownloadCommand extends ImageMapSubCommand {
 
             try (InputStream str = connection.getInputStream()) {
                 BufferedImage image = ImageIO.read(str);
+                if (image == null) {
+                    MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "Downloaded file is not an image!");
+                    return;
+                }
+
                 File outFile = new File(plugin.getDataFolder(), "images" + File.separatorChar + filename);
                 boolean fileExisted = outFile.exists();
                 ImageIO.write(image, "PNG", outFile);
+
                 if (fileExisted) {
                     MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "File already exists, overwriting!");
                     getPlugin().reloadImage(filename);
                 }
             } catch (IllegalArgumentException ex) {
-                MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "Downloaded file is not an image!");
+                MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.WARNING, "Received no data");
                 return;
             }
             MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, "Download complete.");

--- a/src/main/java/net/craftcitizen/imagemaps/ImageMapHelpCommand.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMapHelpCommand.java
@@ -30,6 +30,7 @@ public class ImageMapHelpCommand extends HelpCommand {
             MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, buildMessage("/imagemap place <filename> [size]", " - starts image placement"));
         
         MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, buildMessage("/imagemap download <filename> <sourceURL>", " - downloads an image"));
+        MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, buildMessage("/imagemap delete <filename>", " - deletes an image"));
         MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, buildMessage("/imagemap info <filename>", " - displays image info"));
         MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, buildMessage("/imagemap reload <filename>", " - reloads an image from disk"));
         MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, buildMessage("/imagemap list [page]", " - lists all files in the images folder"));

--- a/src/main/java/net/craftcitizen/imagemaps/ImageMapInfoCommand.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMapInfoCommand.java
@@ -50,11 +50,16 @@ public class ImageMapInfoCommand extends ImageMapSubCommand {
         BaseComponent placeAction = new TextComponent("[Place]");
         placeAction.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("/imagemap place \"%s\"", filename)));
         placeAction.setColor(ChatColor.GOLD);
+        BaseComponent deleteAction = new TextComponent("[Delete]");
+        deleteAction.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("/imagemap delete \"%s\"", filename)));
+        deleteAction.setColor(ChatColor.RED);
         
         BaseComponent actions = new TextComponent("Action: ");
         actions.addExtra(reloadAction);
         actions.addExtra(" ");
         actions.addExtra(placeAction);
+        actions.addExtra(" ");
+        actions.addExtra(deleteAction);
         
         MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.INFO, "Image Information: ");
         MessageUtil.sendMessage(getPlugin(), sender, MessageLevel.NORMAL, String.format("File Name: %s", filename));

--- a/src/main/java/net/craftcitizen/imagemaps/ImageMapListCommand.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMapListCommand.java
@@ -44,6 +44,9 @@ public class ImageMapListCommand extends ImageMapSubCommand {
             BaseComponent placeAction = new TextComponent("[Place]");
             placeAction.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("/imagemap place \"%s\"", filename)));
             placeAction.setColor(ChatColor.GOLD);
+            BaseComponent deleteAction = new TextComponent("[Delete]");
+            deleteAction.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("/imagemap delete \"%s\"", filename)));
+            deleteAction.setColor(ChatColor.RED);
             
             BaseComponent message = new TextComponent(filename);
             message.setColor(even ? ChatColor.GRAY : ChatColor.WHITE);
@@ -53,6 +56,8 @@ public class ImageMapListCommand extends ImageMapSubCommand {
             message.addExtra(reloadAction);
             message.addExtra(" ");
             message.addExtra(placeAction);
+            message.addExtra(" ");
+            message.addExtra(deleteAction);
             
             MessageUtil.sendMessage(plugin, sender, MessageLevel.NORMAL, message);
             even = !even;

--- a/src/main/java/net/craftcitizen/imagemaps/ImageMaps.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMaps.java
@@ -374,21 +374,32 @@ public class ImageMaps extends JavaPlugin implements Listener {
 
     public boolean deleteImage(String filename) {
         File file = new File(getDataFolder(), IMAGES_DIR + File.separatorChar + filename);
+
         boolean fileDeleted = false;
-        if (file.exists()) fileDeleted = file.delete();
+        if (file.exists()) {
+            fileDeleted = file.delete();
+        }
+
         imageCache.remove(filename.toLowerCase());
+
         Iterator<Entry<ImageMap, Integer>> it = maps.entrySet().iterator();
         while (it.hasNext()) {
             Entry<ImageMap, Integer> entry = it.next();
             ImageMap imageMap = entry.getKey();
-            if (!imageMap.getFilename().equalsIgnoreCase(filename)) continue;
-            Integer id = entry.getValue();
+            if (!imageMap.getFilename().equalsIgnoreCase(filename)) {
+                continue;
+            }
+
             @SuppressWarnings("deprecation")
-            MapView map = Bukkit.getMap(id);
-            if (map == null) continue;
+            MapView map = Bukkit.getMap(entry.getValue());
+
+            if (map == null) {
+                continue;
+            }
             map.getRenderers().forEach(map::removeRenderer);
             it.remove();
         }
+
         saveMaps();
         return fileDeleted;
     }

--- a/src/main/java/net/craftcitizen/imagemaps/ImageMaps.java
+++ b/src/main/java/net/craftcitizen/imagemaps/ImageMaps.java
@@ -4,6 +4,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -370,7 +371,28 @@ public class ImageMaps extends JavaPlugin implements Listener {
         
         return PlacementResult.SUCCESS;
     }
-    
+
+    public boolean deleteImage(String filename) {
+        File file = new File(getDataFolder(), IMAGES_DIR + File.separatorChar + filename);
+        boolean fileDeleted = false;
+        if (file.exists()) fileDeleted = file.delete();
+        imageCache.remove(filename.toLowerCase());
+        Iterator<Entry<ImageMap, Integer>> it = maps.entrySet().iterator();
+        while (it.hasNext()) {
+            Entry<ImageMap, Integer> entry = it.next();
+            ImageMap imageMap = entry.getKey();
+            if (!imageMap.getFilename().equalsIgnoreCase(filename)) continue;
+            Integer id = entry.getValue();
+            @SuppressWarnings("deprecation")
+            MapView map = Bukkit.getMap(id);
+            if (map == null) continue;
+            map.getRenderers().forEach(map::removeRenderer);
+            it.remove();
+        }
+        saveMaps();
+        return fileDeleted;
+    }
+
     @SuppressWarnings("deprecation")
     public boolean reloadImage(String filename) {
         if (!imageCache.containsKey(filename.toLowerCase()))

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,6 +10,7 @@ commands:
         usage: |
           /imagemap place <filename> [frameVisible] [frameFixed] [size] - starts image placement
           /imagemap download <filename> <sourceURL> - downloads an image
+          /imagemap delete <filename> - deletes an image
           /imagemap info <filename> - displays image info
           /imagemap reload <filename> - reloads an image from disk
           /imagemap list [page] - lists all files in the images folder
@@ -20,6 +21,7 @@ permissions:
         children:
           imagemaps.place: true
           imagemaps.download: true
+          imagemaps.delete: true
           imagemaps.info: true
           imagemaps.list: true
           imagemaps.reload: true
@@ -29,7 +31,9 @@ permissions:
     imagemaps.place:
         default: op
     imagemaps.download:
-        default: op
+      default: op
+    imagemaps.delete:
+      default: op
     imagemaps.info:
         default: op
     imagemaps.list:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -31,9 +31,9 @@ permissions:
     imagemaps.place:
         default: op
     imagemaps.download:
-      default: op
+        default: op
     imagemaps.delete:
-      default: op
+        default: op
     imagemaps.info:
         default: op
     imagemaps.list:


### PR DESCRIPTION
I implemented a `delete` sub command that removes images from the file system and the image cache and removes the map renderers. 

I also optimized the `download` command a little, by setting a proper `User-Agent` (so that CDNs like Cloudflare no longer block the request) and handling already existing images a little better.